### PR TITLE
Use official Heroku apt buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/ddollar/heroku-buildpack-apt
+https://github.com/heroku/heroku-buildpack-apt
 https://github.com/heroku/heroku-buildpack-ruby
 


### PR DESCRIPTION
Switching out the url of the apt buildpack to use the official Heroku one that will be maintained past 2017-01-01.
